### PR TITLE
Add addressPrefix for RPC's

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "axios": "0.28.0",
     "crypto-js": "4.1.1",
     "decimal.js": "10.4.3",
+    "dsteem": "^0.11.3",
     "flatlist-react": "1.5.0",
     "joi": "^17.13.3",
     "keychain-sdk": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "axios": "0.28.0",
     "crypto-js": "4.1.1",
     "decimal.js": "10.4.3",
-    "dsteem": "^0.11.3",
     "flatlist-react": "1.5.0",
     "joi": "^17.13.3",
     "keychain-sdk": "^0.7.0",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -1249,6 +1249,38 @@
     "message": "Delegation",
     "description": "Website request title"
   },
+  "dialog_change_network_rpc_title": {
+    "message": "Change Network RPC",
+    "description": "Change network RPC title"
+  },
+  "dialog_change_network_rpc_description": {
+    "message": "The website is requesting to change your network RPC settings. Please verify the details below before confirming.",
+    "description": "Change network RPC description"
+  },
+  "dialog_rpc_url": {
+    "message": "RPC URL",
+    "description": "RPC URL label"
+  },
+  "dialog_address_prefix": {
+    "message": "Address Prefix",
+    "description": "Address prefix label"
+  },
+  "dialog_chain_id": {
+    "message": "Chain ID",
+    "description": "Chain ID label"
+  },
+  "dialog_testnet": {
+    "message": "Testnet",
+    "description": "Testnet label"
+  },
+  "dialog_full_rpc_details": {
+    "message": "Full RPC Details",
+    "description": "Full RPC details label"
+  },
+  "dialog_set_as_default_rpc": {
+    "message": "Set this as my default RPC/node",
+    "description": "Set as default RPC checkbox label"
+  },
   "dialog_title_wit": {
     "message": "Witness Vote",
     "description": "Website request title"
@@ -4074,6 +4106,18 @@
   "html_popup_settings_notifications_condition": {
     "message": "Condition",
     "description": "Condition"
+  },
+  "html_popup_settings_rpc_saved": {
+    "message": "Network RPC configuration changed successfully!",
+    "description": "Success message when RPC settings are updated"
+  },
+  "html_popup_settings_rpc_saved_keys_regenerated": {
+    "message": "Network RPC changed and public keys regenerated for new address prefix!",
+    "description": "Success message when RPC settings are updated and keys are regenerated due to prefix change"
+  },
+  "html_popup_settings_rpc_added": {
+    "message": "Network RPC added to your list successfully!",
+    "description": "Success message when RPC is added but not set as default"
   },
   "html_popup_reset_form": {
     "message": "Reset",

--- a/public/steem_keychain.js
+++ b/public/steem_keychain.js
@@ -1010,6 +1010,38 @@ var steem_keychain = {
     this.dispatchCustomEvent('swRequest', request, callback);
   },
 
+  /**
+   * This function allows a website to request changing the user's active network RPC settings
+   * @example
+   * const keychain = window.steem_keychain;
+   * const rpcConfig = {
+   *   uri: 'https://testapi.moecki.online',
+   *   addressPrefix: 'MTN',
+   *   chainId: '1aa939649afcc54c67e01a809967f75b8bee5d928aa6bdf237d0d5d6bfbc5c22',
+   *   testnet: true
+   * };
+   * keychain.requestChangeNetworkRpc(rpcConfig, (response) => {
+   *   if (response.success) {
+   *     console.log('RPC changed successfully');
+   *   }
+   * });
+   * 
+   * @param {Object} rpcConfig RPC configuration object
+   * @param {String} rpcConfig.uri RPC node URL
+   * @param {String} rpcConfig.addressPrefix Address prefix (e.g., 'STM', 'MTN')
+   * @param {String} [rpcConfig.chainId] Blockchain chain ID (optional)
+   * @param {Boolean} rpcConfig.testnet Whether this is a testnet
+   * @param {requestCallback} callback Function that handles Keychain's response to the request
+   */
+  requestChangeNetworkRpc: function (rpcConfig, callback) {
+    const request = {
+      type: 'changeNetworkRpc',
+      rpc: rpcConfig,
+    };
+
+    this.dispatchCustomEvent('swRequest', request, callback);
+  },
+
   // Send the customEvent
   dispatchCustomEvent: function (name, data, callback) {
     this.requests[this.current_id] = callback;

--- a/src/background/requests/init.ts
+++ b/src/background/requests/init.ts
@@ -1,9 +1,9 @@
 import MkModule from '@background/mk.module';
 import { RequestsHandler } from '@background/requests/request-handler';
 import {
-  KeychainRequest,
-  KeychainRequestTypes,
-  RequestTransfer,
+    KeychainRequest,
+    KeychainRequestTypes,
+    RequestTransfer,
 } from '@interfaces/keychain.interface';
 import { LocalAccount } from '@interfaces/local-account.interface';
 import { NoConfirm } from '@interfaces/no-confirm.interface';
@@ -16,8 +16,8 @@ import LocalStorageUtils from 'src/utils/localStorage.utils';
 import Logger from 'src/utils/logger.utils';
 import { isWhitelisted } from 'src/utils/preferences.utils';
 import {
-  anonymous_requests,
-  getRequiredWifType,
+    anonymous_requests,
+    getRequiredWifType,
 } from 'src/utils/requests.utils';
 import * as Logic from './logic';
 
@@ -70,6 +70,15 @@ export default async (
     let account = accounts.find((e) => e.name === username);
     if (type === KeychainRequestTypes.addAccount) {
       Logic.addAccountRequest(requestHandler, tab!, request, domain, account);
+    } else if (type === 'changeNetworkRpc' as any) {
+      // Change network RPC doesn't require an account
+      Logic.requestWithConfirmation(
+        requestHandler,
+        tab!,
+        request,
+        domain,
+        rpc,
+      );
     } else if (type === KeychainRequestTypes.transfer) {
       Logic.transferRequest(
         requestHandler,

--- a/src/background/requests/operations/index.ts
+++ b/src/background/requests/operations/index.ts
@@ -8,6 +8,7 @@ import {
   broadcastRemoveKeyAuthority,
 } from '@background/requests/operations/ops/authority';
 import { broadcastOperations } from '@background/requests/operations/ops/broadcast';
+import { changeNetworkRpc } from '@background/requests/operations/ops/change-network-rpc';
 import { convert } from '@background/requests/operations/ops/convert';
 import { broadcastCreateClaimedAccount } from '@background/requests/operations/ops/create-claimed-account';
 import { broadcastCustomJson } from '@background/requests/operations/ops/custom-json';
@@ -155,6 +156,13 @@ export const performOperation = async (
         break;
       case KeychainRequestTypes.swap:
         message = await broadcastSwap(requestHandler, data, options);
+        break;
+      case 'changeNetworkRpc' as any:
+        message = await changeNetworkRpc(
+          requestHandler,
+          data as any,
+          options?.setAsDefault || false,
+        );
         break;
     }
     chrome.tabs.sendMessage(tab, message);

--- a/src/background/requests/operations/ops/change-network-rpc.ts
+++ b/src/background/requests/operations/ops/change-network-rpc.ts
@@ -1,0 +1,97 @@
+import MkModule from '@background/mk.module';
+import { createMessage } from '@background/requests/operations/operations.utils';
+import { RequestsHandler } from '@background/requests/request-handler';
+import RPCModule from '@background/rpc.module';
+import { RequestId } from '@interfaces/keychain.interface';
+import { Rpc } from '@interfaces/rpc.interface';
+import AccountUtils from '@popup/steem/utils/account.utils';
+import { KeysUtils } from '@popup/steem/utils/keys.utils';
+import { LocalStorageKeyEnum } from '@reference-data/local-storage-key.enum';
+import LocalStorageUtils from 'src/utils/localStorage.utils';
+
+interface ChangeNetworkRpcRequest {
+  type: string;
+  rpc: Rpc;
+  request_id: number;
+}
+
+export const changeNetworkRpc = async (
+  requestHandler: RequestsHandler,
+  data: ChangeNetworkRpcRequest & RequestId,
+  setAsDefault: boolean,
+) => {
+  const { rpc, request_id } = data;
+  let err = null;
+
+  try {
+    // Get current RPC to check if prefix changed
+    const currentRpc = await LocalStorageUtils.getValueFromLocalStorage(
+      LocalStorageKeyEnum.CURRENT_RPC,
+    );
+    const oldPrefix = currentRpc?.addressPrefix || 'STM';
+    const newPrefix = rpc.addressPrefix || 'STM';
+
+    // Always add RPC to the custom RPC list
+    const savedCustomRpc = await LocalStorageUtils.getValueFromLocalStorage(
+      LocalStorageKeyEnum.RPC_LIST,
+    );
+    const rpcList = savedCustomRpc ? savedCustomRpc : [];
+    
+    // Check if RPC already exists in the list
+    const existingRpcIndex = rpcList.findIndex((r: Rpc) => r.uri === rpc.uri);
+    if (existingRpcIndex === -1) {
+      // Add new RPC to the list
+      rpcList.push(rpc);
+      await LocalStorageUtils.saveValueInLocalStorage(
+        LocalStorageKeyEnum.RPC_LIST,
+        rpcList,
+      );
+    }
+
+    // If user chose to set as default, save as active RPC
+    if (setAsDefault && rpc) {
+      // If address prefix changed, regenerate public keys for all accounts BEFORE saving RPC
+      if (oldPrefix !== newPrefix) {
+        try {
+          // Update the address prefix in KeysUtils BEFORE regenerating
+          KeysUtils.updatePopupAddressPrefix(newPrefix);
+          
+          const mk = await MkModule.getMk();
+          if (mk) {
+            const accounts = await AccountUtils.getAccountsFromLocalStorage(mk);
+            const updatedAccounts = await KeysUtils.regeneratePublicKeys(accounts, mk);
+            await AccountUtils.saveAccounts(updatedAccounts, mk);
+          }
+        } catch (error) {
+          // Log error but don't fail the RPC change
+          // Silent fail - keys will be regenerated next time user opens popup
+        }
+      }
+      
+      // Save the RPC AFTER regenerating keys
+      await RPCModule.setActiveRpc(rpc);
+    }
+
+    // Return success response using createMessage
+    return await createMessage(
+      null,
+      { rpc, setAsDefault, prefixChanged: oldPrefix !== newPrefix },
+      data as any,
+      setAsDefault && oldPrefix !== newPrefix
+        ? await chrome.i18n.getMessage('html_popup_settings_rpc_saved_keys_regenerated')
+        : setAsDefault
+        ? await chrome.i18n.getMessage('html_popup_settings_rpc_saved')
+        : await chrome.i18n.getMessage('html_popup_settings_rpc_added'),
+      await chrome.i18n.getMessage('unknown_error'),
+    );
+  } catch (e) {
+    err = e;
+    return await createMessage(
+      err,
+      null,
+      data as any,
+      null,
+      await chrome.i18n.getMessage('unknown_error'),
+    );
+  }
+};

--- a/src/background/rpc.module.ts
+++ b/src/background/rpc.module.ts
@@ -4,18 +4,34 @@ import { config as HiveTxConfig } from '@steempro/steem-tx-js';
 import { Rpc } from 'src/interfaces/rpc.interface';
 import LocalStorageUtils from 'src/utils/localStorage.utils';
 
+let _currentAddressPrefix: string = 'STM';
+
+(async () => {
+  const rpc = await LocalStorageUtils.getValueFromLocalStorage(
+    LocalStorageKeyEnum.CURRENT_RPC,
+  );
+  if (rpc?.addressPrefix) {
+    _currentAddressPrefix = rpc.addressPrefix;
+  }
+})();
+
 const init = async () => {
   const rpc = await RPCModule.getActiveRpc();
   if (!rpc || rpc.uri === 'DEFAULT') {
     HiveTxConfig.node = DefaultRpcs[0].uri;
     HiveTxConfig.chain_id =
       '0000000000000000000000000000000000000000000000000000000000000000';
+    _currentAddressPrefix = 'STM';
   } else {
     HiveTxConfig.node = rpc.uri;
     if (rpc.chainId) {
       HiveTxConfig.chain_id =
-        '0000000000000000000000000000000000000000000000000000000000000000';
+        rpc.chainId;
     }
+    if (rpc.addressPrefix) {
+      HiveTxConfig.address_prefix = rpc.addressPrefix;
+    }
+    _currentAddressPrefix = rpc.addressPrefix || 'STM';
   }
 };
 
@@ -27,8 +43,12 @@ const setActiveRpc = async (rpc: Rpc) => {
     if (rpc.chainId) {
       HiveTxConfig.chain_id = rpc.chainId;
     }
+    if (rpc.addressPrefix) {
+      HiveTxConfig.address_prefix = rpc.addressPrefix;
+    }
   }
-  await LocalStorageUtils.saveValueInLocalStorage(
+  _currentAddressPrefix = rpc.addressPrefix || 'STM'; 
+ await LocalStorageUtils.saveValueInLocalStorage(
     LocalStorageKeyEnum.CURRENT_RPC,
     rpc,
   );
@@ -40,10 +60,23 @@ const getActiveRpc = async (): Promise<Rpc> => {
   );
 };
 
+const getCurrentAddressPrefix = (): string => {
+  return _currentAddressPrefix;
+};
+
+const getCurrentAddressPrefixFromStorage = async (): Promise<string> => {
+  const rpc = await LocalStorageUtils.getValueFromLocalStorage(
+    LocalStorageKeyEnum.CURRENT_RPC,
+  );
+  return rpc?.addressPrefix || 'STM';
+};
+
 const RPCModule = {
   setActiveRpc,
   getActiveRpc,
   init,
+  getCurrentAddressPrefix,
+  getCurrentAddressPrefixFromStorage
 };
 
 export default RPCModule;

--- a/src/content-scripts/web-interface/input-validation.ts
+++ b/src/content-scripts/web-interface/input-validation.ts
@@ -315,6 +315,15 @@ const encodeMultisig = Joi.object({
   username,
 });
 
+const changeNetworkRpc = Joi.object({
+  rpc: Joi.object({
+    uri: Joi.string().uri().required(),
+    addressPrefix: Joi.string().required(),
+    chainId: Joi.string().allow('').optional(),
+    testnet: Joi.boolean().required(),
+  }).required(),
+});
+
 const schemas = {
   encodeMultisig,
   decode,
@@ -345,6 +354,7 @@ const schemas = {
   addAccount,
   convert,
   swap,
+  changeNetworkRpc,
 };
 
 export const commonRequestParams = {

--- a/src/dialog/pages/request-confirmation.tsx
+++ b/src/dialog/pages/request-confirmation.tsx
@@ -12,6 +12,7 @@ import AddKeyAuthority from 'src/dialog/pages/requests/authority/add-key-authori
 import RemoveAccountAuthority from 'src/dialog/pages/requests/authority/remove-account-authority';
 import RemoveKeyAuthority from 'src/dialog/pages/requests/authority/remove-key-authority';
 import Broadcast from 'src/dialog/pages/requests/broadcast';
+import ChangeNetworkRpc from 'src/dialog/pages/requests/change-network-rpc';
 import Convert from 'src/dialog/pages/requests/convert';
 import CreateClaimedAccount from 'src/dialog/pages/requests/create-claimed-account';
 import CustomJson from 'src/dialog/pages/requests/custom-json';
@@ -26,7 +27,6 @@ import CreateProposal from 'src/dialog/pages/requests/proposals/create-proposal'
 import RemoveProposal from 'src/dialog/pages/requests/proposals/remove-proposal';
 import UpdateProposalVote from 'src/dialog/pages/requests/proposals/update-proposal-vote';
 import Proxy from 'src/dialog/pages/requests/proxy';
-import SendToken from 'src/dialog/pages/requests/send-token';
 import SignBuffer from 'src/dialog/pages/requests/sign-buffer';
 import SignTx from 'src/dialog/pages/requests/sign-tx';
 import Swap from 'src/dialog/pages/requests/swap';
@@ -94,8 +94,6 @@ const RequestConfirmation = ({ data }: Props) => {
       return <CreateProposal {...data} data={data.data} />;
     case KeychainRequestTypes.removeProposal:
       return <RemoveProposal {...data} data={data.data} />;
-    case KeychainRequestTypes.sendToken:
-      return <SendToken {...data} data={data.data} />;
     case KeychainRequestTypes.createClaimedAccount:
       return <CreateClaimedAccount {...data} data={data.data} />;
     case KeychainRequestTypes.post:
@@ -104,6 +102,9 @@ const RequestConfirmation = ({ data }: Props) => {
       return <Broadcast {...data} data={data.data} />;
     case KeychainRequestTypes.swap:
       return <Swap {...data} data={data.data} />;
+    // @ts-ignore - Custom extension type not in shared library
+    case 'changeNetworkRpc':
+      return <ChangeNetworkRpc {...data} data={data.data as any} />;
     default:
       return null;
   }

--- a/src/dialog/pages/requests/change-network-rpc.tsx
+++ b/src/dialog/pages/requests/change-network-rpc.tsx
@@ -1,0 +1,137 @@
+import { RequestId } from '@interfaces/keychain.interface';
+import { Rpc } from '@interfaces/rpc.interface';
+import { BackgroundCommand } from '@reference-data/background-message-key.enum';
+import React, { useState } from 'react';
+import ButtonComponent, {
+    ButtonType,
+} from 'src/common-ui/button/button.component';
+import { CheckboxPanelComponent } from 'src/common-ui/checkbox/checkbox-panel/checkbox-panel.component';
+import { LoadingComponent } from 'src/common-ui/loading/loading.component';
+import { Separator } from 'src/common-ui/separator/separator.component';
+import CollaspsibleItem from 'src/dialog/components/collapsible-item/collapsible-item';
+import DialogHeader from 'src/dialog/components/dialog-header/dialog-header.component';
+import RequestItem from 'src/dialog/components/request-item/request-item';
+
+interface RequestChangeNetworkRpc {
+  rpc: Rpc;
+}
+
+type Props = {
+  data: RequestChangeNetworkRpc & RequestId;
+  domain: string;
+  tab: number;
+  rpc: Rpc;
+};
+
+const ChangeNetworkRpc = (props: Props) => {
+  const { data, domain, tab } = props;
+  const [setAsDefault, setSetAsDefault] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = () => {
+    setLoading(true);
+
+    // Accept the transaction to send success response back to the requesting site
+    // The backend will handle saving RPC if setAsDefault is true
+    chrome.runtime.sendMessage({
+      command: BackgroundCommand.ACCEPT_TRANSACTION,
+      value: {
+        data: data,
+        tab: tab,
+        domain: domain,
+        keep: false,
+        options: { setAsDefault },
+      },
+    });
+  };
+
+  const handleCancel = () => {
+    window.close();
+  };
+
+  return (
+    <div className="operation">
+      <div
+        className="scrollable"
+        style={{
+          height: '70%',
+          overflow: 'scroll',
+          display: 'flex',
+          flexDirection: 'column',
+          rowGap: '16px',
+        }}>
+        <div>
+          <DialogHeader title={chrome.i18n.getMessage('dialog_change_network_rpc_title')} />
+          <div className="operation-header">
+            {chrome.i18n.getMessage('dialog_change_network_rpc_description')}
+          </div>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-around',
+            flex: 1,
+            flexDirection: 'column',
+          }}>
+          <div className="operation-body">
+            <div className="fields">
+              <RequestItem
+                title="dialog_rpc_url"
+                content={data.rpc.uri}
+              />
+              <Separator type={'horizontal'} fullSize />
+              <RequestItem
+                title="dialog_address_prefix"
+                content={data.rpc.addressPrefix || 'STM'}
+              />
+              <Separator type={'horizontal'} fullSize />
+              <RequestItem
+                title="dialog_chain_id"
+                content={data.rpc.chainId || 'Default'}
+              />
+              <Separator type={'horizontal'} fullSize />
+              <RequestItem
+                title="dialog_testnet"
+                content={data.rpc.testnet ? 'Yes' : 'No'}
+              />
+              <Separator type={'horizontal'} fullSize />
+              <CollaspsibleItem
+                title="dialog_full_rpc_details"
+                content={JSON.stringify(data.rpc, undefined, 2)}
+                pre
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <CheckboxPanelComponent
+        onChange={setSetAsDefault}
+        checked={setAsDefault}
+        skipTranslation
+        title={chrome.i18n.getMessage('dialog_set_as_default_rpc')}
+      />
+
+      {!loading && (
+        <div className="operation-buttons">
+          <ButtonComponent
+            label="dialog_cancel"
+            type={ButtonType.ALTERNATIVE}
+            onClick={handleCancel}
+            height="small"
+          />
+          <ButtonComponent
+            type={ButtonType.IMPORTANT}
+            label="dialog_confirm"
+            onClick={handleConfirm}
+            height="small"
+          />
+        </div>
+      )}
+
+      <LoadingComponent hide={!loading} />
+    </div>
+  );
+};
+
+export default ChangeNetworkRpc;

--- a/src/interfaces/keys.interface.ts
+++ b/src/interfaces/keys.interface.ts
@@ -24,6 +24,7 @@ export enum PrivateKeyType {
 
 export interface TransactionOptions {
   metaData?: TransactionOptionsMetadata;
+  setAsDefault?: boolean;
 }
 
 export interface TransactionOptionsMetadata {

--- a/src/interfaces/rpc.interface.ts
+++ b/src/interfaces/rpc.interface.ts
@@ -2,4 +2,5 @@ export interface Rpc {
   uri: string;
   testnet: boolean;
   chainId?: string;
+  addressPrefix?: string;
 }

--- a/src/popup/steem/actions/active-rpc.actions.ts
+++ b/src/popup/steem/actions/active-rpc.actions.ts
@@ -1,16 +1,40 @@
+import { AppThunk } from '@popup/multichain/actions/interfaces';
 import { SteemActionType } from '@popup/steem/actions/action-type.enum';
+import AccountUtils from '@popup/steem/utils/account.utils';
+import { KeysUtils } from '@popup/steem/utils/keys.utils';
+import MkUtils from '@popup/steem/utils/mk.utils';
 import { SteemTxUtils } from '@popup/steem/utils/steem-tx.utils';
 import { BackgroundCommand } from '@reference-data/background-message-key.enum';
 import { Rpc } from 'src/interfaces/rpc.interface';
 
-export const setActiveRpc = (rpc: Rpc) => {
+export const setActiveRpc = (rpc: Rpc): AppThunk => async (dispatch, getState) => {
   SteemTxUtils.setRpc(rpc);
+  
+  const oldPrefix = KeysUtils.getPopupAddressPrefix();
+  KeysUtils.updatePopupAddressPrefix(rpc.addressPrefix || 'STM');
+  const newPrefix = rpc.addressPrefix || 'STM';
+  
+  // If address prefix changed, regenerate public keys for all accounts
+  if (oldPrefix !== newPrefix) {
+    try {
+      const mk = await MkUtils.getMkFromLocalStorage();
+      if (mk) {
+        const accounts = await AccountUtils.getAccountsFromLocalStorage(mk);
+        const updatedAccounts = await KeysUtils.regeneratePublicKeys(accounts, mk);
+        await AccountUtils.saveAccounts(updatedAccounts, mk);
+      }
+    } catch (error) {
+      //console.warn('Failed to regenerate public keys:', error);
+    }
+  }
+  
   chrome.runtime.sendMessage({
     command: BackgroundCommand.SAVE_RPC,
     value: rpc,
   });
-  return {
+  
+  dispatch({
     type: SteemActionType.SET_ACTIVE_RPC,
     payload: rpc,
-  };
+  });
 };

--- a/src/popup/steem/pages/app-container/home/home.component.tsx
+++ b/src/popup/steem/pages/app-container/home/home.component.tsx
@@ -29,7 +29,6 @@ import { ConnectedProps, connect } from 'react-redux';
 import { LocalAccount } from 'src/interfaces/local-account.interface';
 import LocalStorageUtils from 'src/utils/localStorage.utils';
 import Logger from 'src/utils/logger.utils';
-import { VersionLogUtils } from 'src/utils/version-log.utils';
 import { WhatsNewUtils } from 'src/utils/whats-new.utils';
 
 const Home = ({
@@ -57,9 +56,16 @@ const Home = ({
       refreshActiveAccount();
     }
     initWhatsNew();
-    initCheckKeysOnAccounts(accounts);
     initCheckVestingRoutes();
   }, []);
+
+  useEffect(() => {
+    if (activeRpc && activeRpc.uri !== 'NULL' && accounts.length > 0) {
+      setTimeout(() => {
+        initCheckKeysOnAccounts(accounts);
+      }, 1000);
+    }
+  }, [activeRpc, accounts]);
 
   const initWhatsNew = async () => {
     const lastVersionSeen = await LocalStorageUtils.getValueFromLocalStorage(

--- a/src/popup/steem/pages/app-container/home/wallet-info-section/wallet-info-section.component.tsx
+++ b/src/popup/steem/pages/app-container/home/wallet-info-section/wallet-info-section.component.tsx
@@ -141,24 +141,24 @@ PropsFromRedux) => {
         <WalletInfoSectionItemComponent
           tokenSymbol="STEEM"
           icon={SVGIcons.WALLET_STEEM_LOGO}
-          mainValue={activeAccount.account.balance}
+          mainValue={activeAccount?.account?.balance ?? '0.000 STEEM'}
           mainValueLabel={currencyLabels.steem}
-          subValue={activeAccount.account.savings_balance}
+          subValue={activeAccount?.account?.savings_balance ?? '0.000 STEEM'}
           subValueLabel={chrome.i18n.getMessage('popup_html_wallet_savings')}
         />
         <WalletInfoSectionItemComponent
           tokenSymbol="SBD"
           icon={SVGIcons.WALLET_SBD_LOGO}
-          mainValue={activeAccount.account.sbd_balance}
+          mainValue={activeAccount?.account?.sbd_balance ?? '0.000 SBD'}
           mainValueLabel={currencyLabels.sbd}
-          subValue={activeAccount.account.savings_sbd_balance}
+          subValue={activeAccount?.account?.savings_sbd_balance ?? '0.000 SBD'}
           subValueLabel={chrome.i18n.getMessage('popup_html_wallet_savings')}
         />
         <WalletInfoSectionItemComponent
           tokenSymbol="SP"
           icon={SVGIcons.WALLET_SP_LOGO}
           mainValue={FormatUtils.toSP(
-            activeAccount.account.vesting_shares as string,
+            (activeAccount?.account?.vesting_shares as string) ?? '0 VESTS',
             globalProperties.globals,
           )}
           mainValueLabel={currencyLabels.sp}

--- a/src/popup/steem/pages/app-container/settings/accounts/create-account/create-account-step-two/create-account-step-two.component.tsx
+++ b/src/popup/steem/pages/app-container/settings/accounts/create-account/create-account-step-two/create-account-step-two.component.tsx
@@ -1,3 +1,4 @@
+import RPCModule from '@background/rpc.module';
 import { LocalAccount } from '@interfaces/local-account.interface';
 import {
   addToLoadingList,
@@ -48,6 +49,12 @@ const CreateAccountStepTwo = ({
   const [masterKey, setMasterKey] = useState('');
   const [generatedKeys, setGeneratedKeys] = useState(emptyKeys);
   const [keysTextVersion, setKeysTextVersion] = useState('');
+  const [userName, setUserName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [addressPrefix, setAddressPrefix] = useState('STM');
 
   const accountName = navParams?.newUsername;
   const price = navParams?.price;
@@ -61,9 +68,16 @@ const CreateAccountStepTwo = ({
 
   useEffect(() => {
     setTitleContainerProperties({
-      title: 'popup_html_create_account',
+      title: 'popup_accounts_create_new_account',
       isBackButtonEnabled: true,
     });
+    
+    // Initialize address prefix from storage
+    const initAddressPrefix = async () => {
+      const prefix = await RPCModule.getCurrentAddressPrefixFromStorage();
+      setAddressPrefix(prefix);
+    };
+    initAddressPrefix();
     generateMasterKey();
   }, []);
 
@@ -80,22 +94,22 @@ const CreateAccountStepTwo = ({
     setGeneratedKeys({
       owner: {
         private: owner.toString(),
-        public: owner.createPublic().toString(),
+        public: owner.createPublic(addressPrefix).toString(),
       },
       active: {
         private: active.toString(),
-        public: active.createPublic().toString(),
+        public: active.createPublic(addressPrefix).toString(),
       },
       posting: {
         private: posting.toString(),
-        public: posting.createPublic().toString(),
+        public: posting.createPublic(addressPrefix).toString(),
       },
       memo: {
         private: memo.toString(),
-        public: memo.createPublic().toString(),
+        public: memo.createPublic(addressPrefix).toString(),
       },
     });
-  }, [masterKey]);
+  }, [masterKey, addressPrefix]);
 
   useEffect(() => {
     if (masterKey.length) {

--- a/src/popup/steem/pages/app-container/settings/advanced-settings/rpc-nodes/rpc-nodes.component.tsx
+++ b/src/popup/steem/pages/app-container/settings/advanced-settings/rpc-nodes/rpc-nodes.component.tsx
@@ -1,3 +1,4 @@
+import RPCModule from '@background/rpc.module';
 import {
   DefaultAccountHistoryApis,
   DefaultSteemEngineRpcs,
@@ -61,8 +62,10 @@ const RpcNodes = ({
   const [switchAuto, setSwitchAuto] = useState(true);
   const [addRpcNodeUri, setAddRpcNodeUri] = useState('');
   const [addRpcNodeChainId, setAddRpcNodeChainId] = useState('');
+  const [addRpcNodeAddressPrefix, setAddRpcNodeAddressPrefix] = useState('');
   const [addRpcNodeTestnet, setAddRpcNodeTestnet] = useState(false);
   const [setNewRpcAsActive, setSetNewRpcAsActive] = useState(false);
+  const [currentAddressPrefix, setCurrentAddressPrefix] = useState('STM');
 
   const [steemRpcOptions, setSteemRpcOptions] = useState(
     allRpc.map((rpc) => {
@@ -168,6 +171,7 @@ const RpcNodes = ({
     });
     initCustomRpcList();
     initSwitchAuto();
+    initAddressPrefix();
   }, []);
 
   useEffect(() => {
@@ -221,6 +225,9 @@ const RpcNodes = ({
       uri: addRpcNodeUri,
       testnet: addRpcNodeTestnet,
       chainId: addRpcNodeChainId.length ? addRpcNodeChainId : undefined,
+      addressPrefix: addRpcNodeAddressPrefix.length
+        ? addRpcNodeAddressPrefix
+        : undefined,
     };
     setIsAddRpcPanelDisplayed(false);
     RpcUtils.addCustomRpc(newCustomRpc);
@@ -263,6 +270,11 @@ const RpcNodes = ({
     } else {
       setErrorMessage('html_popup_url_not_valid');
     }
+  };
+
+  const initAddressPrefix = async () => {
+    const addressPrefix = await RPCModule.getCurrentAddressPrefixFromStorage();
+    setCurrentAddressPrefix(addressPrefix);
   };
 
   return (
@@ -348,7 +360,17 @@ const RpcNodes = ({
                   onEnterPress={saveNewSteemRpc}
                 />
               )}
-
+              {addRpcNodeTestnet && (
+                <InputComponent
+                  dataTestId="input-node-address-prefix"
+                  type={InputType.TEXT}
+                  value={addRpcNodeAddressPrefix}
+                  onChange={setAddRpcNodeAddressPrefix}
+                  placeholder="Address Prefix"
+                  skipPlaceholderTranslation={true}
+                  onEnterPress={saveNewSteemRpc}
+                />
+              )}
               <CheckboxComponent
                 dataTestId="checkbox-set-new-rpc-as-active"
                 title="popup_html_set_new_rpc_as_active"

--- a/src/popup/steem/steem-app.component.tsx
+++ b/src/popup/steem/steem-app.component.tsx
@@ -23,6 +23,7 @@ import { AddAccountRouterComponent } from '@popup/steem/pages/add-account/add-ac
 import { AppRouterComponent } from '@popup/steem/pages/app-container/app-router.component';
 import AccountUtils from '@popup/steem/utils/account.utils';
 import ActiveAccountUtils from '@popup/steem/utils/active-account.utils';
+import { KeysUtils } from '@popup/steem/utils/keys.utils';
 import RpcUtils from '@popup/steem/utils/rpc.utils';
 import React, { useEffect, useState } from 'react';
 import { ConnectedProps, connect } from 'react-redux';
@@ -32,7 +33,6 @@ import { SplashscreenComponent } from 'src/common-ui/splashscreen/splashscreen.c
 import Config from 'src/config';
 import { LocalAccount } from 'src/interfaces/local-account.interface';
 import { Screen } from 'src/reference-data/screen.enum';
-import { ColorsUtils } from 'src/utils/colors.utils';
 import { useWorkingRPC } from 'src/utils/rpc-switcher.utils';
 let rpc: string | undefined = '';
 const HiveApp = ({
@@ -123,6 +123,8 @@ const HiveApp = ({
   const initApplication = async () => {
     // ColorsUtils.downloadColors();
     loadCurrencyPrices();
+
+    await KeysUtils.initializePopupAddressPrefix();
 
     const storedAccounts = await AccountUtils.hasStoredAccounts();
 

--- a/src/popup/steem/utils/account.utils.ts
+++ b/src/popup/steem/utils/account.utils.ts
@@ -1,3 +1,10 @@
+import { CurrencyPrices } from '@interfaces/bittrex.interface';
+import { HiveInternalMarketLockedInOrders } from '@interfaces/steem-market.interface';
+import EncryptUtils from '@popup/steem/utils/encrypt.utils';
+import { KeysUtils } from '@popup/steem/utils/keys.utils';
+import MkUtils from '@popup/steem/utils/mk.utils';
+import { SteemTxUtils } from '@popup/steem/utils/steem-tx.utils';
+import { AccountValueType } from '@reference-data/account-value-type.enum';
 import {
   AccountUpdateOperation,
   Authority,
@@ -6,13 +13,6 @@ import {
   DynamicGlobalProperties,
   ExtendedAccount,
 } from '@steempro/dsteem/lib/index-browser';
-import { CurrencyPrices } from '@interfaces/bittrex.interface';
-import { HiveInternalMarketLockedInOrders } from '@interfaces/steem-market.interface';
-import EncryptUtils from '@popup/steem/utils/encrypt.utils';
-import { KeysUtils } from '@popup/steem/utils/keys.utils';
-import MkUtils from '@popup/steem/utils/mk.utils';
-import { SteemTxUtils } from '@popup/steem/utils/steem-tx.utils';
-import { AccountValueType } from '@reference-data/account-value-type.enum';
 import Config from 'src/config';
 import { Accounts } from 'src/interfaces/accounts.interface';
 import { ActiveAccount, RC } from 'src/interfaces/active-account.interface';
@@ -28,7 +28,6 @@ import { LocalStorageKeyEnum } from 'src/reference-data/local-storage-key.enum';
 import FormatUtils from 'src/utils/format.utils';
 import LocalStorageUtils from 'src/utils/localStorage.utils';
 import Logger from 'src/utils/logger.utils';
-
 export enum AccountErrorMessages {
   INCORRECT_KEY = 'popup_accounts_incorrect_key',
   INCORRECT_USER = 'popup_accounts_incorrect_user',
@@ -356,14 +355,7 @@ const downloadAccounts = async (acc: LocalAccount[], mk: string) => {
 };
 
 const getAccountValue = (
-  {
-    sbd_balance,
-    balance,
-    vesting_shares,
-    savings_balance,
-    savings_sbd_balance,
-    name,
-  }: ExtendedAccount,
+  account: ExtendedAccount | undefined,
   prices: CurrencyPrices,
   props: DynamicGlobalProperties,
   // tokensBalance: TokenBalance[],
@@ -374,6 +366,18 @@ const getAccountValue = (
   // hiddenTokensList: string[],
 ) => {
   if (accountValueType === AccountValueType.HIDDEN) return '⁎ ⁎ ⁎';
+
+  // Guard against undefined account
+  if (!account) return 0;
+
+  const {
+    sbd_balance,
+    balance,
+    vesting_shares,
+    savings_balance,
+    savings_sbd_balance,
+    name,
+  } = account;
 
   if (!prices.steem_dollars?.usd || !prices.steem?.usd) return 0;
   // const userLayerTwoPortfolio = PortfolioUtils.generateUserLayerTwoPortolio(

--- a/src/popup/steem/utils/rpc.utils.ts
+++ b/src/popup/steem/utils/rpc.utils.ts
@@ -1,10 +1,8 @@
-import { SteemTxUtils } from '@popup/steem/utils/steem-tx.utils';
 import axios from 'axios';
 import { Rpc } from 'src/interfaces/rpc.interface';
 import { DefaultRpcs } from 'src/reference-data/default-rpc.list';
 import { LocalStorageKeyEnum } from 'src/reference-data/local-storage-key.enum';
 import LocalStorageUtils from 'src/utils/localStorage.utils';
-import Logger from 'src/utils/logger.utils';
 
 const getFullList = (): Rpc[] => {
   return DefaultRpcs.map((rpc: Rpc) => {
@@ -113,7 +111,7 @@ const checkRpcStatus = async (uri: string): Promise<boolean> => {
 
     return false;
   } catch (err) {
-    console.error('RPC NOK', uri, err);
+    //console.error('RPC NOK', uri, err);
     return false;
   }
 };
@@ -150,7 +148,7 @@ const RpcUtils = {
   saveCustomRpc,
   deleteCustomRpc,
   findRpc,
-  checkRpcStatus,
+  checkRpcStatus
 };
 
 export default RpcUtils;

--- a/src/popup/steem/utils/steem-tx.utils.ts
+++ b/src/popup/steem/utils/steem-tx.utils.ts
@@ -41,6 +41,9 @@ const setRpc = async (rpc: Rpc) => {
   if (rpc.chainId) {
     SteemTxConfig.chain_id = rpc.chainId;
   }
+  if (rpc.addressPrefix) {
+    SteemTxConfig.address_prefix = rpc.addressPrefix;
+  }
 };
 const sendOperation = async (
   operations: Operation[],

--- a/src/popup/steem/utils/steem-tx.utils.ts
+++ b/src/popup/steem/utils/steem-tx.utils.ts
@@ -151,7 +151,7 @@ const createSignAndBroadcastTransaction = async (
                   operations,
                   extensions: []
               },
-              { active: key },
+              { [method.toLowerCase()]: key },
               (err: any, res: any) => {
                   if (err) {
                       reject(err);
@@ -164,7 +164,7 @@ const createSignAndBroadcastTransaction = async (
       return {
         status: 'ok' as string,
         tx_id: (result && (result as any).id) ? (result as any).id : '',
-        isUsingMultisig: false,
+        isUsingMultisig: false
       } as SteemTxBroadcastResult;
     } catch (error) {
       Logger.error(error);
@@ -196,6 +196,7 @@ const createSignAndBroadcastTransaction = async (
           status: response as string,
           tx_id: '',
           isUsingMultisig: true,
+          keyType: method,
         } as SteemTxBroadcastResult;
       }
     } catch (err) {
@@ -215,6 +216,7 @@ const createSignAndBroadcastTransaction = async (
           status: 'ok' as string,
           tx_id: response,
           isUsingMultisig: true,
+          keyType: method,
         } as SteemTxBroadcastResult;
       }
     }

--- a/src/utils/rpc-switcher.utils.ts
+++ b/src/utils/rpc-switcher.utils.ts
@@ -19,7 +19,7 @@ export const useWorkingRPC = async (activeRpc?: Rpc) => {
   )) {
     if (await RpcUtils.checkRpcStatus(rpc.uri)) {
       if (switchAuto) {
-        store.dispatch(setActiveRpc(rpc));
+        (store.dispatch as any)(setActiveRpc(rpc));
       } else {
         store.dispatch(setSwitchToRpc(rpc));
         store.dispatch(setDisplayChangeRpcPopup(true));


### PR DESCRIPTION
This change add addressPrefix for RPC's (important for testnets)
Since pub keys are saved it will regenerate public keys whenever the RPC changes
I had to do some tricks and add delays to get rid of the wrong keys message at initialization.